### PR TITLE
Allow some favicons to be kept on the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm install react-favicon --save
 * Animate through a list of urls
 * Toggle animation
 * Alert bubbles
+* Allow some favicons to be kept on the page, which may be desirable for desktop Safari
 
 ## Usage
 ```javascript

--- a/dist/react-favicon.js
+++ b/dist/react-favicon.js
@@ -85,7 +85,7 @@ var Favicon = function (_React$Component) {
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps) {
-      if (prevProps.url === this.props.url && prevProps.animated === this.props.animated && prevProps.alertCount === this.props.alertCount) return;
+      if (prevProps.url === this.props.url && prevProps.animated === this.props.animated && prevProps.alertCount === this.props.alertCount && prevProps.keepIconLink === this.props.keepIconLink) return;
 
       Favicon.update();
     }
@@ -104,6 +104,7 @@ var Favicon = function (_React$Component) {
     value: function draw() {
       if (typeof document === 'undefined') return;
 
+      var activeInstance = Favicon.getActiveInstance();
       if (typeof linkEl === 'undefined') {
         var head = document.getElementsByTagName('head')[0];
         linkEl = document.createElement('link');
@@ -112,12 +113,15 @@ var Favicon = function (_React$Component) {
 
         // remove existing favicons
         var links = head.getElementsByTagName("link");
-        for (var i = links.length; --i >= 0; /\bicon\b/i.test(links[i].getAttribute("rel")) && head.removeChild(links[i])) {}
+        for (var i = links.length; --i >= 0;) {
+          if (/\bicon\b/i.test(links[i].getAttribute("rel")) && !activeInstance.props.keepIconLink(links[i])) {
+            head.removeChild(links[i]);
+          }
+        }
 
         head.appendChild(linkEl);
       }
 
-      var activeInstance = Favicon.getActiveInstance();
       var currentUrl;
 
       if (activeInstance.props.url instanceof Array) {
@@ -169,7 +173,10 @@ Favicon.displayName = 'Favicon';
 Favicon.defaultProps = {
   alertCount: null,
   animated: true,
-  animationDelay: 500
+  animationDelay: 500,
+  keepIconLink: function keepIconLink() {
+    return false;
+  }
 };
 Favicon.mountedInstances = [];
 

--- a/lib/react-favicon.js
+++ b/lib/react-favicon.js
@@ -54,7 +54,8 @@ class Favicon extends React.Component {
   static defaultProps = {
     alertCount: null,
     animated: true,
-    animationDelay: 500
+    animationDelay: 500,
+    keepIconLink: function() { return false; }
   };
 
   static mountedInstances = [];
@@ -66,6 +67,7 @@ class Favicon extends React.Component {
   static draw() {
     if (typeof document === 'undefined') return
 
+    var activeInstance = Favicon.getActiveInstance();
     if (typeof linkEl === 'undefined') {
       var head = document.getElementsByTagName('head')[0];
       linkEl = document.createElement('link');
@@ -74,12 +76,15 @@ class Favicon extends React.Component {
 
       // remove existing favicons
       var links = head.getElementsByTagName("link");
-      for (var i = links.length; --i >= 0; /\bicon\b/i.test(links[i].getAttribute("rel")) && head.removeChild(links[i])) {}
+      for (var i = links.length; --i >= 0;) {
+        if (/\bicon\b/i.test(links[i].getAttribute("rel")) && !activeInstance.props.keepIconLink(links[i])) {
+          head.removeChild(links[i])
+        }
+      }
 
       head.appendChild(linkEl);
     }
 
-    var activeInstance = Favicon.getActiveInstance();
     var currentUrl;
 
     if (activeInstance.props.url instanceof Array) {
@@ -137,7 +142,8 @@ class Favicon extends React.Component {
   componentDidUpdate(prevProps) {
     if (prevProps.url === this.props.url &&
         prevProps.animated === this.props.animated &&
-        prevProps.alertCount === this.props.alertCount) return
+        prevProps.alertCount === this.props.alertCount &&
+        prevProps.keepIconLink === this.props.keepIconLink) return
 
     Favicon.update();
   }


### PR DESCRIPTION
This can be useful for the case where we want to animate the favicons in most browsers, but leave
the desktop Safari mask icon in place.

* New prop `keep` which defaults to a falsy anonymous function
* If the `rel` attribute matches `\bicon\b` and calling that function returns false, discard the favicon