### PR TITLE
Clearing interval on unmount.

### DIFF
--- a/dist/react-favicon.js
+++ b/dist/react-favicon.js
@@ -83,6 +83,12 @@ var Favicon = function (_React$Component) {
       Favicon.update();
     }
   }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      var activeInstance = Favicon.getActiveInstance();
+      clearInterval(activeInstance.state.animationLoop);
+    }
+  }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps) {
       if (prevProps.url === this.props.url && prevProps.animated === this.props.animated && prevProps.alertCount === this.props.alertCount && prevProps.keepIconLink === this.props.keepIconLink) return;

--- a/lib/react-favicon.js
+++ b/lib/react-favicon.js
@@ -139,6 +139,11 @@ class Favicon extends React.Component {
     Favicon.update();
   }
 
+  componentWillUnmount() {
+    var activeInstance = Favicon.getActiveInstance();
+    clearInterval(activeInstance.state.animationLoop);
+  }
+
   componentDidUpdate(prevProps) {
     if (prevProps.url === this.props.url &&
         prevProps.animated === this.props.animated &&


### PR DESCRIPTION
Unmounting an active instance of react-favicon currently goes haywire due to the setInterval not being cleared.

This PR clears the setInterval onComponentUnmount to resolve that issue.