### PR TITLE
resolving unmet peer dependency issues with react 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/oflisback/react-favicon",
   "peerDependencies": {
-    "react": ">=0.12.0 <= ^16.0.0"
+    "react": ">=0.12.0 <= 16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
The current peer dependency declaration causes an unmet peer dependency message for any project that's running React 15. This solves it.