### PR TITLE
Reduce the package size by ~50%

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-**/.*
-example
-script
-specs
-bower.json
-karma.conf.js
-webpack.config.js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.13",
   "description": "Favicon for react",
   "main": "dist/react-favicon.js",
+  "files": ["dist"],
   "scripts": {
     "build": "babel lib/react-favicon.js > dist/react-favicon.js"
   },


### PR DESCRIPTION
This change 
* enables a whitelist for packaging, instead of using `.npmignore`.
* reduces the tar size from `7KB` to `3.6KB`, & the expanded package size from `36KB` to `18KB`.
* removes any files that aren't required by any consumer of this package.