### PR TITLE
feat(iconSize): Add iconSize option to allow user to control favicon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ npm install react-favicon --save
 | alertCount     | number or string           | null        | No       | Number or string to display as icon overlay.       |
 | alertFillColor | string                     | red         | No       | Alert bubble background color.                     |
 | alertTextColor | string                     | white       | No       | Alert bubble text color.                           |
+| iconSize       | number                     | 16          | No       | Size of the favicon to avoid pixelization          |
 | animated       | boolean                    | true        | No       | True to animate favicon (for supported icons)      |
 | animationDelay | number                     | 500         | No       | Time between animation frames                      |
 | keepIconLink   | function()                 | () => false | No       | Return true to remove icon link from document head |

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -25,7 +25,7 @@ const App = () => {
   const [alertFillColor, setAlertFillColor] = useState('red')
   const [alertTextColor, setAlertTextColor] = useState('white')
   const [renderOverlay, setRenderOverlay] = useState(false)
-  const [iconSize, setIconSize] = useState(undefined);
+  const [iconSize, setIconSize] = useState(16);
   const [url, setUrl] = useState(favicons[0].url)
 
   return (
@@ -38,11 +38,13 @@ const App = () => {
         renderOverlay={
           renderOverlay
             ? (canvas, context) => {
-                const top = canvas.height - 9
-                const left = canvas.width - 7 - 1
-                const bottom = 16
-                const right = 16
-                const radius = 2
+
+                // Create a rounded square taking 1/4 of the icon size;
+                const top = canvas.height / 2;
+                const left = canvas.width / 2;
+                const bottom = canvas.height;
+                const right = canvas.width;
+                const radius = iconSize / 8;
 
                 context.fillStyle = 'green'
                 context.strokeStyle = 'green'
@@ -60,11 +62,13 @@ const App = () => {
                 context.closePath()
                 context.fill()
 
-                context.font = 'bold 10px arial'
+                // Make the text size dynamic depending on the icon size
+                // Useful to avoid shrinking on bigger high res icons
+                context.font = `bold ${iconSize / 1.8}px arial`
                 context.fillStyle = '#FFF'
-                context.textAlign = 'right'
+                context.textAlign = 'left'
                 context.textBaseline = 'top'
-                context.fillText('a', 15, 6)
+                context.fillText('a', left + canvas.width / 8, top);
               }
             : null
         }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -21,11 +21,11 @@ const favicons = [
 
 const App = () => {
   const [animated, setAnimated] = useState(true)
-  const [alert, setAlert] = useState(false)
-  const [alertCount, setAlertCount] = useState(1)
+  const [alertCount, setAlertCount] = useState(undefined)
   const [alertFillColor, setAlertFillColor] = useState('red')
   const [alertTextColor, setAlertTextColor] = useState('white')
   const [renderOverlay, setRenderOverlay] = useState(false)
+  const [iconSize, setIconSize] = useState(undefined);
   const [url, setUrl] = useState(favicons[0].url)
 
   return (
@@ -69,6 +69,7 @@ const App = () => {
             : null
         }
         url={url}
+        iconSize={iconSize}
       />
       <div
         style={{
@@ -136,46 +137,13 @@ const App = () => {
             style={{ alignItems: 'center', display: 'flex', height: '50px' }}
           >
             <input
-              onChange={(e) => setAlert(e.target.checked)}
+              onChange={(e) => setAlertCount(e.target.checked ? 1 : 0)}
               type='checkbox'
               style={{ height: '20px', width: '20px' }}
+              checked={alertCount > 0}
             />
             <div>Alert count</div>
-            {alert && (
-              <>
-                : {alertCount}
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    marginLeft: '5px',
-                  }}
-                >
-                  <div
-                    onClick={() => setAlertCount(alertCount + 1)}
-                    style={{
-                      border: '1px solid black',
-                      display: 'flex',
-                      justifyContent: 'center',
-                      margin: '1px',
-                    }}
-                  >
-                    +
-                  </div>
-                  <div
-                    onClick={() => setAlertCount(Math.max(0, alertCount - 1))}
-                    style={{
-                      border: '1px solid black',
-                      display: 'flex',
-                      justifyContent: 'center',
-                      margin: '1px',
-                    }}
-                  >
-                    -
-                  </div>
-                </div>
-              </>
-            )}
+            <input type={"text"} value={alertCount} onChange={(e) => setAlertCount(e.target.value)} />
           </div>
           <div style={{ alignItems: 'center', display: 'flex' }}>
             {['red', 'black', 'blue'].map((color) => (
@@ -198,6 +166,28 @@ const App = () => {
               style={{ alignItems: 'center', display: 'flex', height: '50px' }}
             >
               <div style={{ marginLeft: '4px' }}>Alert fill color</div>
+            </div>
+          </div>
+          <div style={{ alignItems: 'center', display: 'flex' }}>
+            {[16, 32, 57, 72, 96, 114, 120, 128, 144, 152, 180, 192, 195].map((size) => (
+              <div
+                key={size}
+                onClick={() => setIconSize(size)}
+                value={size}
+                style={{
+                  border: iconSize === size ? "2px solid black" : "1px solid black",
+                  margin: '2px',
+                  width: '25px',
+                  height: '20px',
+                }}
+              >
+                {size}
+              </div>
+            ))}
+            <div
+              style={{ alignItems: 'center', display: 'flex', height: '50px' }}
+            >
+              <div style={{ marginLeft: '4px' }}>Icon size</div>
             </div>
           </div>
           <div style={{ alignItems: 'center', display: 'flex' }}>


### PR DESCRIPTION
Add a new props: `iconSize`

This allow the user to control the favicon size depending of what he want (32x32, 16x16, ...).

I had to refactor a bit the way we draw the alerts to make it dynamic but same looking depending of the iconSize provided.


This fix the issue in #31

I could have dismissed the all "16x16" initial limitation, however, I prefer to avoid introducing breaking changes. With the new props way, the behavior should stay the same for the people who doesn't experience the "pixelization" bug.


### Screenshots:

https://user-images.githubusercontent.com/8771783/136668175-3d76f205-218f-4e24-91dc-dc41ffed7642.mov

Here a close up of the pixelization with 16x16 vs 32x32 iconSize:

https://user-images.githubusercontent.com/8771783/136668208-e21ddd05-7641-4562-aaf7-cde12636f7ce.mov



